### PR TITLE
Explicit dependency of httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                        <version>4.5.5</version>
+                </dependency>
+		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId>
 			<version>3.1</version>


### PR DESCRIPTION
Add dependency into pom for the org.apache.httpcomponents:httpclient which supports SNI when Jenkins runs behind a reverse proxy which is secured by SSL.